### PR TITLE
calibration selection fix for the variation of tango devices' model numbers

### DIFF
--- a/Assets/HoloKitSDK/Scripts/HoloKitCalibration.cs
+++ b/Assets/HoloKitSDK/Scripts/HoloKitCalibration.cs
@@ -103,18 +103,19 @@ namespace HoloKit {
             }
             #elif UNITY_ANDROID
 
-			Debug.Log("SystemInfo.deviceModel:" + SystemInfo.deviceModel);
-            switch (SystemInfo.deviceModel) {
-				case "asus ASUS_A002":
-                    loadZenPhoneARTangoCalibration(cameraRig);
-                    break;
-				case "LENOVO Lenovo PB2-690Y":
-                    loadLenovoPhab2ProTangoCalibration(cameraRig);
-                    break;
-                default:
-                    loadZenPhoneARTangoCalibration(cameraRig);
-                    Debug.LogWarning("Your Android device is not officially supported by HoloKitSDK.");
-                    break;
+            Debug.Log("SystemInfo.deviceModel:" + SystemInfo.deviceModel);
+            if (SystemInfo.deviceModel.Contains("ASUS_A002"))
+            {
+                loadZenPhoneARTangoCalibration(cameraRig);
+            }
+            else if (SystemInfo.deviceModel.Contains("PB2-690"))
+            {
+                loadLenovoPhab2ProTangoCalibration(cameraRig);
+            }
+            else
+            {
+                loadZenPhoneARTangoCalibration(cameraRig);
+                Debug.LogWarning("Your Android device is not officially supported by HoloKitSDK.");
             }
             #endif
         }


### PR DESCRIPTION
calibration selection fix for the variation of tango devices' model numbers
There's multiple model number for tango devices.

Zenfone AR
ASUS_A002
ASUS_A002A

Phab 2 Pro
PB2-690Y
PB2-690M
PB2-690N